### PR TITLE
Fixed typographical error, changed aplication to application in README.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ http://help.adobe.com/en_US/air/extensions/index.html<br />
 # Installation
 Extension ID: com.pozirk.AndroidInAppPurchase<br />
 Add "InAppPurchase.ane" and "air\InAppPurchase\bin\InAppPurchase.swc" to your AIR project.<br />
-Add the following lines to your AIR Aplication-app.xml file inside &lt;manifestAdditions&gt; section:<br />
+Add the following lines to your AIR Application-app.xml file inside &lt;manifestAdditions&gt; section:<br />
 <br />
 &lt;uses-permission android:name="com.android.vending.BILLING" /&gt;<br />
 &lt;application android:enabled="true"&gt;<br />


### PR DESCRIPTION
@pozirk, I've corrected a typographical error in the documentation of the [AndroidInAppPurchase](https://github.com/pozirk/AndroidInAppPurchase) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
